### PR TITLE
Allow container actions to be async

### DIFF
--- a/examples/advanced-flow/baskets/todo/index.js
+++ b/examples/advanced-flow/baskets/todo/index.js
@@ -3,16 +3,23 @@
 import { createComponents } from 'react-adone';
 import type { State } from './types';
 
-import * as actions from './actions';
+import * as actionDefs from './actions';
+
+type Actions = typeof actionDefs;
+type ContainerProps = {| selectedUser: string | null |};
 
 const initialState: State = {
   data: null,
   loading: false,
 };
 
-const { Subscriber: TodoSubscriber } = createComponents<State, typeof actions>({
+export const {
+  Container: TodoContainer,
+  Subscriber: TodoSubscriber,
+} = createComponents<State, Actions, ContainerProps>({
   initialState,
-  actions,
+  actions: actionDefs,
+  onContainerUpdate: () => ({ actions }, { selectedUser }) => {
+    if (selectedUser) actions.load(selectedUser);
+  },
 });
-
-export { TodoSubscriber };

--- a/examples/advanced-flow/baskets/user/index.js
+++ b/examples/advanced-flow/baskets/user/index.js
@@ -3,8 +3,11 @@
 import { createComponents, createSelector } from 'react-adone';
 import type { State } from './types';
 
-import * as actions from './actions';
+import * as actionDefs from './actions';
 import * as selectors from './selectors';
+
+type Actions = typeof actionDefs;
+type ContainerProps = {||};
 
 const initialState: State = {
   selected: null,
@@ -12,17 +15,19 @@ const initialState: State = {
   loading: false,
 };
 
-const { Subscriber: UserSubscriber } = createComponents<State, typeof actions>({
+export const {
+  Container: UserContainer,
+  Subscriber: UserSubscriber,
+} = createComponents<State, Actions, ContainerProps>({
   initialState,
-  actions,
+  actions: actionDefs,
+  onContainerInit: () => ({ actions }) => actions.load(),
 });
 
-const UserSelectedSubscriber = createSelector<
+export const UserSelectedSubscriber = createSelector<
   $Call<typeof selectors.getSelected, State>,
-  typeof actions
+  Actions
 >(
   UserSubscriber,
   selectors.getSelected
 );
-
-export { UserSubscriber, UserSelectedSubscriber };

--- a/examples/advanced-flow/components/todo-list.js
+++ b/examples/advanced-flow/components/todo-list.js
@@ -1,8 +1,8 @@
 // @flow
-import React, { Component } from 'react';
+import React from 'react';
 
 import { UserSelectedSubscriber } from '../baskets/user';
-import { TodoSubscriber } from '../baskets/todo';
+import { TodoContainer, TodoSubscriber } from '../baskets/todo';
 import { type TodoModel } from '../baskets/todo/types';
 
 type TodoItemProps = {
@@ -20,47 +20,34 @@ type TodoListProps = {
   onLoad: (uid: string) => any,
 };
 
-class TodoList extends Component<TodoListProps> {
-  componentDidUpdate(prevProps) {
-    const { selectedUser, onLoad } = this.props;
-    if (selectedUser && selectedUser !== prevProps.selectedUser) {
-      onLoad(selectedUser);
-    }
-  }
-  render() {
-    const { todos, loading, selectedUser } = this.props;
-
-    if (!selectedUser || !todos || loading) {
-      return (
-        <div className="TodoList">
-          {loading ? 'Loading...' : 'Select a user first'}
-        </div>
-      );
-    }
-
-    return (
-      <ul className="TodoList">
-        {todos.map(todo => (
-          <TodoItem key={todo.title} todo={todo} />
-        ))}
-      </ul>
-    );
-  }
-}
+const TodoList = ({ todos, loading, selectedUser }: TodoListProps) =>
+  !selectedUser || !todos || loading ? (
+    <div className="TodoList">
+      {loading ? 'Loading...' : 'Select a user first'}
+    </div>
+  ) : (
+    <ul className="TodoList">
+      {todos.map(todo => (
+        <TodoItem key={todo.title} todo={todo} />
+      ))}
+    </ul>
+  );
 
 const SubscribedTodoList = () => (
   <UserSelectedSubscriber>
     {({ sel }) => (
-      <TodoSubscriber>
-        {({ data, loading, load }) => (
-          <TodoList
-            todos={data}
-            loading={loading}
-            onLoad={load}
-            selectedUser={sel}
-          />
-        )}
-      </TodoSubscriber>
+      <TodoContainer selectedUser={sel}>
+        <TodoSubscriber>
+          {({ data, loading, load }) => (
+            <TodoList
+              todos={data}
+              loading={loading}
+              onLoad={load}
+              selectedUser={sel}
+            />
+          )}
+        </TodoSubscriber>
+      </TodoContainer>
     )}
   </UserSelectedSubscriber>
 );

--- a/examples/advanced-flow/components/user-list.js
+++ b/examples/advanced-flow/components/user-list.js
@@ -1,7 +1,7 @@
 // @flow
-import React, { Component } from 'react';
+import React from 'react';
 
-import { UserSubscriber } from '../baskets/user';
+import { UserContainer, UserSubscriber } from '../baskets/user';
 import { type UserModel } from '../baskets/user/types';
 
 type UserItemProps = {
@@ -23,44 +23,39 @@ type UserListProps = {
   users: UserModel[],
   loading: boolean,
   selected: string | null,
-  onLoad: () => any,
   onSelect: (id: string) => any,
 };
 
-class UserList extends Component<UserListProps> {
-  componentDidMount() {
-    this.props.onLoad();
-  }
-  render() {
-    const { users, selected, loading, onSelect } = this.props;
-    if (loading) return <div className="UserList">Loading...</div>;
-    return (
-      <ul className="UserList">
-        {users.map(user => (
-          <UserItem
-            key={user.id}
-            user={user}
-            isSelected={user.id === selected}
-            onClick={() => onSelect(user.id)}
-          />
-        ))}
-      </ul>
-    );
-  }
-}
+const UserList = ({ users, selected, loading, onSelect }: UserListProps) =>
+  loading ? (
+    <div className="UserList">Loading...</div>
+  ) : (
+    <ul className="UserList">
+      {users.map(user => (
+        <UserItem
+          key={user.id}
+          user={user}
+          isSelected={user.id === selected}
+          onClick={() => onSelect(user.id)}
+        />
+      ))}
+    </ul>
+  );
 
 const SubscribedUserList = () => (
-  <UserSubscriber>
-    {({ data, loading, selected, select, load }) => (
-      <UserList
-        users={data || []}
-        loading={loading}
-        selected={selected}
-        onSelect={select}
-        onLoad={load}
-      />
-    )}
-  </UserSubscriber>
+  <UserContainer isGlobal>
+    <UserSubscriber>
+      {({ data, loading, selected, select, load }) => (
+        <UserList
+          users={data || []}
+          loading={loading}
+          selected={selected}
+          onSelect={select}
+          onLoad={load}
+        />
+      )}
+    </UserSubscriber>
+  </UserContainer>
 );
 
 export default SubscribedUserList;

--- a/examples/advanced-scoped-flow/baskets/form.js
+++ b/examples/advanced-scoped-flow/baskets/form.js
@@ -9,6 +9,10 @@ type State = {
   toUsers: number,
 };
 
+type ContainerProps = {
+  remoteUsers: number,
+};
+
 const initialState: State = {
   message: '',
   isValid: false,
@@ -40,12 +44,12 @@ const actions = {
 const {
   Subscriber: FormSubscriber,
   Container: FormContainer,
-} = createComponents<State, typeof actions>({
+} = createComponents<State, typeof actions, ContainerProps>({
   name: 'form',
   initialState,
   actions,
-  onContainerUpdate: (state, variables) => {
-    return { ...state, toUsers: variables.remoteUsers };
+  onContainerUpdate: () => ({ setState }, { remoteUsers }) => {
+    setState({ toUsers: remoteUsers });
   },
 });
 export { FormSubscriber, FormContainer };

--- a/examples/advanced-scoped-flow/baskets/messages.js
+++ b/examples/advanced-scoped-flow/baskets/messages.js
@@ -22,7 +22,8 @@ const actions = {
 
 const { Subscriber: MessagesSubscriber } = createComponents<
   State,
-  typeof actions
+  typeof actions,
+  void
 >({
   name: 'messages',
   initialState,

--- a/examples/advanced-scoped-flow/baskets/theme.js
+++ b/examples/advanced-scoped-flow/baskets/theme.js
@@ -6,14 +6,21 @@ type State = {
   color: string,
 };
 
+type ContainerProps = {
+  defaultColor: string,
+};
+
 const initialState: State = {
   color: '',
 };
 
 const actions = {
-  change: (value: string): BasketAction<State> => ({ setState }) => {
+  change: (value?: string): BasketAction<State> => (
+    { setState },
+    { defaultColor }
+  ) => {
     setState({
-      color: value,
+      color: value || defaultColor,
     });
   },
 };
@@ -21,14 +28,17 @@ const actions = {
 const {
   Subscriber: ThemeSubscriber,
   Container: ThemeContainer,
-} = createComponents<State, typeof actions>({
+} = createComponents<State, typeof actions, ContainerProps>({
   name: 'theme',
   initialState,
   actions,
-  onContainerInit: (state, variables) => {
-    // this gets currently called also when component remount
-    // so we have to check state status and apply default only on first mount
-    return { ...state, color: state.color || variables.defaultColor };
+  onContainerInit: () => ({ getState, actions: boundActions }) => {
+    // this gets currently called also when component remounts
+    // so it is important to check state status and apply default only on first mount
+    const { color } = getState();
+    if (!color) {
+      boundActions.change();
+    }
   },
 });
 

--- a/examples/basic-flow/basket.js
+++ b/examples/basic-flow/basket.js
@@ -18,11 +18,13 @@ const actions = {
   },
 };
 
-const { Subscriber: CountSubscriber } = createComponents<State, typeof actions>(
-  {
-    initialState,
-    actions,
-  }
-);
+const { Subscriber: CountSubscriber } = createComponents<
+  State,
+  typeof actions,
+  {||}
+>({
+  initialState,
+  actions,
+});
 
 export { CountSubscriber };

--- a/src/__tests__/bind-actions.test.js
+++ b/src/__tests__/bind-actions.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { basketMock, storeMock } from './mocks';
-import bindActions from '../bind-actions';
+import { bindActions } from '../bind-actions';
 import combineMiddlewares from '../middlewares';
 
 jest.mock('../middlewares');

--- a/src/__tests__/flow.js
+++ b/src/__tests__/flow.js
@@ -68,7 +68,7 @@ basket = { key: ['bla'], initialState: { count: 0 }, actions };
 /**
  * createComponents types tests
  */
-Cc = createComponents<State, typeof actions>({
+Cc = createComponents<State, typeof actions, void>({
   name: 'Type',
   initialState: { count: 0 },
   actions,

--- a/src/bind-actions.js
+++ b/src/bind-actions.js
@@ -8,24 +8,28 @@ const createNamedMutator = (store, actionName) =>
       }
     : store.mutator;
 
-export default function bindActions(
-  actions,
+export const bindAction = (
   store,
-  getContainerProps = () => ({})
-) {
-  return Object.keys(actions).reduce((acc, k) => {
-    // Setting mutator name so we can log action name for better debuggability
-    const namedMutator = createNamedMutator(store, k);
-    acc[k] = (...args) => {
-      return actions[k](...args)(
-        {
-          setState: namedMutator,
-          getState: store.getState,
-          actions: acc,
-        },
-        getContainerProps()
-      );
-    };
+  actionFn,
+  actionKey,
+  getContainerProps,
+  otherActions
+) => {
+  // Setting mutator name so we can log action name for better debuggability
+  const namedMutator = createNamedMutator(store, actionKey);
+  return (...args) =>
+    actionFn(...args)(
+      {
+        setState: namedMutator,
+        getState: store.getState,
+        actions: otherActions,
+      },
+      getContainerProps()
+    );
+};
+
+export const bindActions = (actions, store, getContainerProps = () => ({})) =>
+  Object.keys(actions).reduce((acc, k) => {
+    acc[k] = bindAction(store, actions[k], k, getContainerProps, actions);
     return acc;
   }, {});
-}

--- a/src/components/__tests__/creators.test.js
+++ b/src/components/__tests__/creators.test.js
@@ -38,8 +38,8 @@ describe('creators', () => {
         actions: {
           updateFoo,
         },
-        onContainerInit: null,
-        onContainerUpdate: null,
+        onContainerInit: expect.any(Function),
+        onContainerUpdate: expect.any(Function),
       });
       expect(hash).toHaveBeenCalledWith('{"foo":"bar"}');
     });
@@ -54,6 +54,8 @@ describe('creators', () => {
           updateFoo,
         },
         name: 'test',
+        onContainerInit: jest.fn(),
+        onContainerUpdate: jest.fn(),
       });
 
       expect(Container.prototype).toBeInstanceOf(ContainerClass);
@@ -66,8 +68,8 @@ describe('creators', () => {
         actions: {
           updateFoo,
         },
-        onContainerInit: null,
-        onContainerUpdate: null,
+        onContainerInit: expect.any(Function),
+        onContainerUpdate: expect.any(Function),
       });
       expect(hash).toHaveBeenCalledWith('{"foo":"bar"}');
     });

--- a/src/components/creators.js
+++ b/src/components/creators.js
@@ -2,6 +2,8 @@ import Container from './container';
 import Subscriber from './subscriber';
 import hash from '../utils/hash';
 
+const noop = () => () => {};
+
 const createSubscriber = basketType =>
   class extends Subscriber {
     static basketType = basketType;
@@ -18,8 +20,8 @@ export function createComponents({
   name = '',
   initialState,
   actions,
-  onContainerInit = null,
-  onContainerUpdate = null,
+  onContainerInit = noop,
+  onContainerUpdate = noop,
 }) {
   const src = !name
     ? Object.keys(actions).reduce((acc, k) => acc + actions[k].toString(), '')

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -29,11 +29,11 @@ export type BasketStore<ST> = {|
   mutator: SetState<ST>,
 |};
 
-export type BasketAction<ST, PR = *> = (
+export type BasketAction<ST, PR = *, AC = *> = (
   {|
     setState: SetState<ST>,
     getState: GetState<ST>,
-    actions: { [key: string]: BasketAction<ST, PR> },
+    actions: AC,
   |},
   containerProps: PR
 ) => *;
@@ -81,25 +81,14 @@ declare export var defaults: {
   mutator: <ST>(prevState: ST, partialState: $Shape<ST>) => ST,
 };
 
-declare export function createComponents<ST, AC>({
+declare export function createComponents<ST, AC, PR>({
   initialState: ST,
   actions: AC,
   name?: string,
+  onContainerInit?: () => BasketAction<ST, PR, AC>,
+  onContainerUpdate?: () => BasketAction<ST, PR, AC>,
 }): {
-  Container: React$ComponentType<{ id?: string }>,
-  Subscriber: React$ComponentType<{
-    children: RenderPropComponent<ST, AC>,
-  }>,
-};
-
-declare export function createComponents<ST, AC, VA>({
-  initialState: ST,
-  actions: AC,
-  name?: string,
-  onContainerInit?: (state: ST, variables: VA) => $Shape<ST>,
-  onContainerUpdate?: (state: ST, variables: VA) => $Shape<ST>,
-}): {
-  Container: React$ComponentType<{ id?: string, variables?: VA }>,
+  Container: React$ComponentType<{ scope?: string, isGlobal?: boolean, ...PR }>,
   Subscriber: React$ComponentType<{
     children: RenderPropComponent<ST, AC>,
   }>,

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,4 @@
-import bindActions from './bind-actions';
+import { bindActions } from './bind-actions';
 import createStore from './create-store';
 
 export const GLOBAL_SCOPE = '__global__';


### PR DESCRIPTION
Use same thunk shape for `onContainerInit` and `onContainerUpdate`, so they can fire also normally defined actions 